### PR TITLE
fix: Vite proxy で .env の API キーが読み込まれない問題を修正

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,24 @@
 import type { ClientRequest } from "node:http";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite-plus";
+
+// .env を process.env に読み込む（Vite が proxy configure 時に参照できるよう）
+try {
+  const lines = readFileSync(resolve(process.cwd(), ".env"), "utf8").split("\n");
+  for (const line of lines) {
+    const match = line.match(/^([^#=\s][^=]*)=(.*)$/);
+    if (match) {
+      const key = match[1].trim();
+      const val = match[2].trim().replace(/^["']|["']$/g, "");
+      if (!(key in process.env)) process.env[key] = val;
+    }
+  }
+} catch {
+  // .env が存在しない場合は無視
+}
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,14 +7,17 @@ import { defineConfig } from "vite-plus";
 
 // .env を process.env に読み込む（Vite が proxy configure 時に参照できるよう）
 try {
-  const lines = readFileSync(resolve(process.cwd(), ".env"), "utf8").split("\n");
-  for (const line of lines) {
-    const match = line.match(/^([^#=\s][^=]*)=(.*)$/);
-    if (match) {
-      const key = match[1].trim();
-      const val = match[2].trim().replace(/^["']|["']$/g, "");
-      if (!(key in process.env)) process.env[key] = val;
-    }
+  const envPath = resolve(process.cwd(), ".env");
+  const content = readFileSync(envPath, "utf8");
+  for (const line of content.split(/\r?\n/)) {
+    const eqIdx = line.indexOf("=");
+    if (eqIdx === -1 || line.trimStart().startsWith("#")) continue;
+    const key = line.slice(0, eqIdx).trim();
+    const val = line
+      .slice(eqIdx + 1)
+      .trim()
+      .replace(/^["']|["']$/g, "");
+    process.env[key] = val;
   }
 } catch {
   // .env が存在しない場合は無視


### PR DESCRIPTION
## Summary

- `vite.config.ts` の Vite proxy ハンドラ内で `process.env["VITE_ANTHROPIC_API_KEY"]` が空になり、Claude API 呼び出し時に 401 Unauthorized が発生していた
- Vite は `.env` を `import.meta.env`（クライアント側）に読み込むが、`process.env`（Node.js サーバー側）への注入は保証されていない
- 設定ファイル先頭で `.env` を明示的に読み込み `process.env` に設定することで修正

## Test plan

- [ ] `vp dev` でサーバー起動後、ゲーム内でキャラクターに質問して Claude からレスポンスが返ることを確認
- [ ] `.env` に `VITE_LLM_PROVIDER=claude` と `VITE_ANTHROPIC_API_KEY` が設定されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)