### PR TITLE
fix: タブ切り替え時に別容疑者のチャットに返答が表示されるバグを修正 (#5)

### DIFF
--- a/src/screens/InterrogationScreen.test.tsx
+++ b/src/screens/InterrogationScreen.test.tsx
@@ -1,8 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
-import { screen } from "@testing-library/react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
 
 import { InterrogationScreen } from "./InterrogationScreen";
-import { renderWithGameSetup, INTERROGATION_ACTIONS, createTurnActions } from "../test/helpers";
+import {
+  renderWithGameSetup,
+  INTERROGATION_ACTIONS,
+  createTurnActions,
+  act,
+} from "../test/helpers";
+import { useGame } from "../state/GameContext";
 
 vi.mock("../hooks/useLLMChat", () => ({
   useLLMChat: vi.fn().mockReturnValue({
@@ -92,5 +98,59 @@ describe("InterrogationScreen", () => {
   it("renders score display", async () => {
     renderWithGameSetup(<InterrogationScreen />, INTERROGATION_ACTIONS);
     expect(await screen.findByText("スコア推定値")).not.toBeNull();
+  });
+
+  it("adds assistant reply to the questioned suspect even if the tab is switched before response resolves", async () => {
+    let resolveResponse!: (value: string) => void;
+    const pendingResponse = new Promise<string>((resolve) => {
+      resolveResponse = resolve;
+    });
+    vi.mocked(useLLMChat).mockReturnValue({
+      sendMessage: vi.fn().mockReturnValue(pendingResponse),
+      isLoading: false,
+      error: null,
+      clearError: vi.fn(),
+      streamingContent: null,
+    });
+
+    let capturedDispatch!: ReturnType<typeof useGame>["dispatch"];
+    let capturedState!: ReturnType<typeof useGame>["state"];
+    function StateCapture() {
+      const { dispatch, state } = useGame();
+      capturedDispatch = dispatch;
+      capturedState = state;
+      return null;
+    }
+
+    renderWithGameSetup(
+      <>
+        <StateCapture />
+        <InterrogationScreen />
+      </>,
+      INTERROGATION_ACTIONS,
+    );
+
+    await screen.findByText("残り質問回数");
+
+    // Send a message to suspect A (char-a, the initial suspect)
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "質問です" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    // Switch to suspect B before the response resolves
+    await act(async () => {
+      capturedDispatch({ type: "SELECT_SUSPECT", suspectId: "char-b" });
+    });
+
+    // Resolve the LLM response
+    await act(async () => {
+      resolveResponse("Aの回答");
+    });
+
+    // Reply must land in char-a's history, not char-b's
+    await waitFor(() => {
+      expect(capturedState.chatHistories["char-a"].some((m) => m.content === "Aの回答")).toBe(true);
+    });
+    expect(capturedState.chatHistories["char-b"].some((m) => m.content === "Aの回答")).toBe(false);
   });
 });

--- a/src/screens/InterrogationScreen.tsx
+++ b/src/screens/InterrogationScreen.tsx
@@ -163,6 +163,10 @@ export function InterrogationScreen() {
 
       if (!currentSuspect || remainingTurns <= 0) return;
 
+      // Capture suspectId before async operation to avoid using stale currentSuspectId
+      // if the user switches tabs while waiting for the response
+      const suspectId = currentSuspect.id;
+
       dispatch({ type: "ADD_USER_MESSAGE", content: userMessage });
 
       const systemPrompt = buildSystemPrompt(currentSuspect, state.scenario, state.difficulty);
@@ -174,7 +178,8 @@ export function InterrogationScreen() {
         const triggeredAnxiety = detectAnxiety(response);
 
         dispatch({
-          type: "ADD_ASSISTANT_MESSAGE",
+          type: "ADD_ASSISTANT_MESSAGE_FOR_SUSPECT",
+          suspectId,
           content: response,
           triggeredAnxiety,
         });

--- a/src/screens/InterrogationScreen.tsx
+++ b/src/screens/InterrogationScreen.tsx
@@ -34,6 +34,8 @@ export function InterrogationScreen() {
     state.difficulty,
   );
 
+  const streamingSuspectIdRef = useRef<string | null>(null);
+
   const [isAnxious, setIsAnxious] = useState(false);
   const anxietyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [errorToast, setErrorToast] = useState<string | null>(null);
@@ -166,6 +168,7 @@ export function InterrogationScreen() {
       // Capture suspectId before async operation to avoid using stale currentSuspectId
       // if the user switches tabs while waiting for the response
       const suspectId = currentSuspect.id;
+      streamingSuspectIdRef.current = suspectId;
 
       dispatch({ type: "ADD_USER_MESSAGE", content: userMessage });
 
@@ -231,7 +234,9 @@ export function InterrogationScreen() {
   const currentSuspectAskAllLoading = askAllLoading[state.currentSuspectId] ?? false;
   const effectiveIsLoading = isLoading || currentSuspectAskAllLoading;
   const effectiveStreamingContent =
-    streamingContent ??
+    (streamingContent && streamingSuspectIdRef.current === state.currentSuspectId
+      ? streamingContent
+      : null) ??
     (currentSuspectAskAllLoading ? (askAllStreaming[state.currentSuspectId] ?? null) : null);
 
   return (

--- a/src/screens/InterrogationScreen.tsx
+++ b/src/screens/InterrogationScreen.tsx
@@ -232,7 +232,9 @@ export function InterrogationScreen() {
 
   const inputDisabled = remainingTurns <= 0;
   const currentSuspectAskAllLoading = askAllLoading[state.currentSuspectId] ?? false;
-  const effectiveIsLoading = isLoading || currentSuspectAskAllLoading;
+  const effectiveIsLoading =
+    (isLoading && streamingSuspectIdRef.current === state.currentSuspectId) ||
+    currentSuspectAskAllLoading;
   const effectiveStreamingContent =
     (streamingContent && streamingSuspectIdRef.current === state.currentSuspectId
       ? streamingContent


### PR DESCRIPTION
## Summary

- `handleSendMessage` で非同期処理前に `suspectId` をキャプチャし、`ADD_ASSISTANT_MESSAGE_FOR_SUSPECT` で正しい容疑者の履歴に返答を追加
- `streamingSuspectIdRef` を導入し、生成中の容疑者と現在表示中のタブが異なる場合はストリーミング内容を非表示
- 同様に `isLoading` も現在タブの容疑者の生成中でない場合は `false` として扱い、「回答生成中」表示が別タブに出ないよう修正
- リグレッションテストを追加

Closes #5

## Test plan

- [ ] 容疑者Aに質問し、生成中に容疑者Bのタブに切り替えて「回答生成中」が表示されないことを確認
- [ ] Aのタブに戻ったときに返答が正しくAの履歴に入っていることを確認
- [ ] `vp test` がすべて通ること（既存の `llm.test.ts` の失敗は今回の変更と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)