### PR TITLE
fix: イージーモードのサジェスト再生成とタブ切り替え時の回答消失を修正

### DIFF
--- a/src/components/SuspectSelector.tsx
+++ b/src/components/SuspectSelector.tsx
@@ -17,9 +17,10 @@ const colorMap: Record<string, string> = {
 
 interface SuspectSelectorProps {
   askAllLoading?: Record<string, boolean>;
+  loadingSuspectId?: string | null;
 }
 
-export function SuspectSelector({ askAllLoading }: SuspectSelectorProps) {
+export function SuspectSelector({ askAllLoading, loadingSuspectId }: SuspectSelectorProps) {
   const { state, dispatch } = useGameState();
 
   function handleSelect(suspectId: string) {
@@ -54,7 +55,7 @@ export function SuspectSelector({ askAllLoading }: SuspectSelectorProps) {
             <span className={`text-xs ${isActive ? "text-gray-400" : "text-gray-600"}`}>
               {character.job} / {character.age}
             </span>
-            {askAllLoading?.[character.id] && (
+            {(askAllLoading?.[character.id] || loadingSuspectId === character.id) && (
               <span className="absolute top-1 left-2 w-2 h-2 rounded-full bg-amber-400 animate-pulse" />
             )}
             {messageCount > 0 && (

--- a/src/hooks/useSuggestions.test.ts
+++ b/src/hooks/useSuggestions.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { renderHook, waitFor } from "@testing-library/react";
+
+import { useSuggestions } from "./useSuggestions";
+import type { CharacterData, ChatMessage, Scenario } from "../types";
+
+vi.mock("../utils/questionSuggester", () => ({
+  generateSuggestions: vi.fn(),
+}));
+
+import { generateSuggestions } from "../utils/questionSuggester";
+
+const mockGenerateSuggestions = vi.mocked(generateSuggestions);
+
+const scenario = {
+  id: "s1",
+  title: "test",
+  crimeType: "test",
+  setting: "test",
+  crimeTime: "test",
+  introParagraphs: [],
+  characters: [] as unknown as Scenario["characters"],
+  guiltyCharacterId: "c1",
+  contradictionExplanation: "",
+  hints: [],
+} satisfies Scenario;
+
+const characterA: CharacterData = {
+  id: "c1",
+  name: "Aさん",
+  job: "会社員",
+  age: "30",
+  personality: "温厚",
+  personalSecret: "秘密A",
+  emoji: "😀",
+  color: "blue",
+  guilty: true,
+  alibiLie: "嘘",
+  contradiction: "矛盾",
+  crimeDetail: "詳細",
+};
+
+const characterB: CharacterData = {
+  id: "c2",
+  name: "Bさん",
+  job: "医師",
+  age: "40",
+  personality: "冷静",
+  personalSecret: "秘密B",
+  emoji: "😎",
+  color: "rose",
+  guilty: false,
+  alibiTruth: "真実",
+};
+
+const noHistory: ChatMessage[] = [];
+
+describe("useSuggestions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGenerateSuggestions.mockResolvedValue(["質問1", "質問2", "質問3"]);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("easyモードでcharacterが未定義の場合はサジェストを生成しない", async () => {
+    const { result } = renderHook(() => useSuggestions(scenario, undefined, noHistory, "easy"));
+    await waitFor(() => expect(result.current.isLoadingSuggestions).toBe(false));
+    expect(mockGenerateSuggestions).not.toHaveBeenCalled();
+    expect(result.current.suggestions).toEqual([]);
+  });
+
+  it("normalモードではサジェストを生成しない", async () => {
+    const { result } = renderHook(() => useSuggestions(scenario, characterA, noHistory, "normal"));
+    await waitFor(() => expect(result.current.isLoadingSuggestions).toBe(false));
+    expect(mockGenerateSuggestions).not.toHaveBeenCalled();
+  });
+
+  it("easyモードで初回サジェストを生成する", async () => {
+    const { result } = renderHook(() => useSuggestions(scenario, characterA, noHistory, "easy"));
+    await waitFor(() => expect(result.current.suggestions).toEqual(["質問1", "質問2", "質問3"]));
+    expect(mockGenerateSuggestions).toHaveBeenCalledTimes(1);
+  });
+
+  it("タブ切り替え（characterId変更）でキャッシュがあれば再生成しない", async () => {
+    let character: CharacterData = characterA;
+    const { result, rerender } = renderHook(() =>
+      useSuggestions(scenario, character, noHistory, "easy"),
+    );
+
+    // 初回生成を待つ
+    await waitFor(() => expect(result.current.suggestions).toEqual(["質問1", "質問2", "質問3"]));
+    expect(mockGenerateSuggestions).toHaveBeenCalledTimes(1);
+
+    // characterB に切り替え
+    mockGenerateSuggestions.mockResolvedValue(["質問B1", "質問B2", "質問B3"]);
+    character = characterB;
+    rerender();
+    await waitFor(() => expect(result.current.suggestions).toEqual(["質問B1", "質問B2", "質問B3"]));
+    expect(mockGenerateSuggestions).toHaveBeenCalledTimes(2);
+
+    // characterA に戻る → キャッシュを使うため再生成しない
+    character = characterA;
+    rerender();
+    await waitFor(() => expect(result.current.suggestions).toEqual(["質問1", "質問2", "質問3"]));
+    expect(mockGenerateSuggestions).toHaveBeenCalledTimes(2); // 増えない
+  });
+
+  it("A のリクエスト進行中に B に切り替えても A のリクエストを abort しない", async () => {
+    let resolveA!: (v: string[]) => void;
+    const promiseA = new Promise<string[]>((res) => {
+      resolveA = res;
+    });
+    mockGenerateSuggestions.mockReturnValueOnce(promiseA);
+    mockGenerateSuggestions.mockResolvedValue(["質問B1", "質問B2", "質問B3"]);
+
+    let character: CharacterData = characterA;
+    const { result, rerender } = renderHook(() =>
+      useSuggestions(scenario, character, noHistory, "easy"),
+    );
+
+    // A の loading 開始
+    await waitFor(() => expect(result.current.isLoadingSuggestions).toBe(true));
+    expect(mockGenerateSuggestions).toHaveBeenCalledTimes(1);
+
+    // B に切り替え → A のリクエストは abort されず継続
+    character = characterB;
+    rerender();
+    await waitFor(() => expect(result.current.suggestions).toEqual(["質問B1", "質問B2", "質問B3"]));
+    expect(mockGenerateSuggestions).toHaveBeenCalledTimes(2); // B の分だけ追加
+
+    // A のリクエストが完了 → A のキャッシュに保存される
+    resolveA(["質問A1", "質問A2", "質問A3"]);
+
+    // A に戻る → キャッシュを使い再生成しない
+    character = characterA;
+    rerender();
+    await waitFor(() => expect(result.current.suggestions).toEqual(["質問A1", "質問A2", "質問A3"]));
+    expect(mockGenerateSuggestions).toHaveBeenCalledTimes(2); // 増えない
+  });
+
+  it("新しいassistantメッセージが追加されたときは再生成する", async () => {
+    let history: ChatMessage[] = [];
+    const { result, rerender } = renderHook(() =>
+      useSuggestions(scenario, characterA, history, "easy"),
+    );
+
+    await waitFor(() => expect(result.current.suggestions).toEqual(["質問1", "質問2", "質問3"]));
+    expect(mockGenerateSuggestions).toHaveBeenCalledTimes(1);
+
+    // assistantメッセージ追加
+    mockGenerateSuggestions.mockResolvedValue(["新質問1", "新質問2", "新質問3"]);
+    history = [{ role: "assistant", content: "返答", timestamp: 1, triggeredAnxiety: false }];
+    rerender();
+
+    await waitFor(() =>
+      expect(result.current.suggestions).toEqual(["新質問1", "新質問2", "新質問3"]),
+    );
+    expect(mockGenerateSuggestions).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/hooks/useSuggestions.ts
+++ b/src/hooks/useSuggestions.ts
@@ -3,6 +3,9 @@ import { useEffect, useRef, useState } from "react";
 import type { CharacterData, ChatMessage, Difficulty, Scenario } from "../types";
 import { generateSuggestions } from "../utils/questionSuggester";
 
+type CacheEntry = { suggestions: string[]; assistantCount: number };
+type PendingEntry = { controller: AbortController; assistantCount: number };
+
 export function useSuggestions(
   scenario: Scenario,
   character: CharacterData | undefined,
@@ -11,45 +14,79 @@ export function useSuggestions(
 ) {
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(false);
-  const abortRef = useRef<AbortController | null>(null);
+  const cacheRef = useRef<Record<string, CacheEntry>>({});
+  const pendingRef = useRef<Record<string, PendingEntry>>({});
+  // Always reflects the currently displayed character
+  const currentCharIdRef = useRef<string | undefined>(undefined);
 
   // Track the last assistant message count to trigger regeneration
   const assistantCount = chatHistory.filter((m) => m.role === "assistant").length;
   const characterId = character?.id;
 
   useEffect(() => {
-    if (difficulty !== "easy" || !character) {
+    currentCharIdRef.current = characterId;
+  });
+
+  useEffect(() => {
+    if (difficulty !== "easy" || !character || !characterId) {
       setSuggestions([]);
+      setIsLoading(false);
       return;
     }
 
-    // Abort previous request
-    abortRef.current?.abort();
+    // Use cache if suggestions were already generated for this character at this assistantCount
+    const cached = cacheRef.current[characterId];
+    if (cached && cached.assistantCount === assistantCount) {
+      setSuggestions(cached.suggestions);
+      setIsLoading(false);
+      return;
+    }
+
+    // If a request is already in flight for this character at this assistantCount, just show loading
+    const existing = pendingRef.current[characterId];
+    if (
+      existing &&
+      !existing.controller.signal.aborted &&
+      existing.assistantCount === assistantCount
+    ) {
+      setSuggestions([]);
+      setIsLoading(true);
+      return;
+    }
+
+    // Abort stale pending request for this character (different assistantCount)
+    existing?.controller.abort();
+    delete pendingRef.current[characterId];
+
     const controller = new AbortController();
-    abortRef.current = controller;
+    pendingRef.current[characterId] = { controller, assistantCount };
 
     setSuggestions([]);
     setIsLoading(true);
 
+    const capturedCharId = characterId;
     generateSuggestions(scenario, character, chatHistory, controller.signal)
       .then((result) => {
         if (!controller.signal.aborted) {
-          setSuggestions(result);
+          cacheRef.current[capturedCharId] = { suggestions: result, assistantCount };
+          delete pendingRef.current[capturedCharId];
+          // Only update UI if this character is still the active tab
+          if (currentCharIdRef.current === capturedCharId) {
+            setSuggestions(result);
+            setIsLoading(false);
+          }
         }
       })
       .catch(() => {
-        // Abort or network error — ignore
-      })
-      .finally(() => {
-        if (!controller.signal.aborted) {
+        if (!controller.signal.aborted && currentCharIdRef.current === capturedCharId) {
           setIsLoading(false);
         }
       });
 
     return () => {
-      controller.abort();
+      // Do not abort on tab switch — let the request complete in the background and cache the result
     };
-    // Regenerate when suspect changes or after a new assistant response
+    // Regenerate only after a new assistant response; use cache on tab switch
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [difficulty, characterId, assistantCount]);
 

--- a/src/screens/InterrogationScreen.tsx
+++ b/src/screens/InterrogationScreen.tsx
@@ -35,6 +35,7 @@ export function InterrogationScreen() {
   );
 
   const streamingSuspectIdRef = useRef<string | null>(null);
+  const [loadingSuspectId, setLoadingSuspectId] = useState<string | null>(null);
 
   const [isAnxious, setIsAnxious] = useState(false);
   const anxietyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -169,6 +170,7 @@ export function InterrogationScreen() {
       // if the user switches tabs while waiting for the response
       const suspectId = currentSuspect.id;
       streamingSuspectIdRef.current = suspectId;
+      setLoadingSuspectId(suspectId);
 
       dispatch({ type: "ADD_USER_MESSAGE", content: userMessage });
 
@@ -198,6 +200,8 @@ export function InterrogationScreen() {
         // AbortError is expected when switching suspects during a request
         if (err instanceof DOMException && err.name === "AbortError") return;
         // Error is already captured by useLLMChat and shown via toast
+      } finally {
+        setLoadingSuspectId(null);
       }
     },
     [
@@ -230,8 +234,10 @@ export function InterrogationScreen() {
 
   if (!currentSuspect) return null;
 
-  const inputDisabled = remainingTurns <= 0;
+  // Disable input whenever ANY LLM request is active to prevent aborting in-flight responses
+  const inputDisabled = remainingTurns <= 0 || isLoading || isAskAllActive;
   const currentSuspectAskAllLoading = askAllLoading[state.currentSuspectId] ?? false;
+  // Typing indicator is only shown for the suspect whose response is being generated
   const effectiveIsLoading =
     (isLoading && streamingSuspectIdRef.current === state.currentSuspectId) ||
     currentSuspectAskAllLoading;
@@ -248,7 +254,7 @@ export function InterrogationScreen() {
         <ScoreBoard />
 
         {/* Suspect selector */}
-        <SuspectSelector askAllLoading={askAllLoading} />
+        <SuspectSelector askAllLoading={askAllLoading} loadingSuspectId={loadingSuspectId} />
 
         {/* Main content area */}
         <div className="flex-1 flex flex-col md:flex-row overflow-hidden">


### PR DESCRIPTION
## Summary

- タブ切り替えのたびにサジェストが再生成される問題を修正（issue #7）
- 質問送信後に別タブに切り替えて送信すると回答が消える問題を修正

## Changes

### サジェストキャッシュ（`useSuggestions.ts`）

- キャラクターごとにサジェストをキャッシュし、同じ容疑者タブに戻っても再生成しない
- リクエスト進行中にタブを切り替えてもabortせずバックグラウンドで継続させ、完了後にキャッシュへ保存
- assistantメッセージが追加されたときのみ再生成する

### 回答消失バグの修正（`InterrogationScreen.tsx`）

- **根本原因**: A に質問して B に切り替えた際、B の入力欄が有効だった。B に送信すると `useLLMChat.sendMessage` が A の進行中リクエストをabortし、A の回答が消えていた
- `inputDisabled` にグローバルな `isLoading` / `isAskAllActive` を含め、どのタブにいてもLLMリクエスト中は送信不可にする
- タイピングインジケーターは `effectiveIsLoading`（現タブ限定）で引き続き制御

### `SuspectSelector.tsx`

- 単発質問の回答生成中も `askAll` と同様にタブに amber の点滅インジケーターを表示

## Test plan

- [x] イージーモードで容疑者Aのサジェストが表示された後、タブを切り替えて戻ってもサジェストが再生成されないことを確認
- [x] 容疑者Aに質問中に別タブに切り替えると、入力欄が無効化されていることを確認
- [x] 容疑者Aに質問中に切り替えたタブに amber の点が表示されることを確認
- [x] Aに質問して待機後、タブを戻るとAの回答が正しく表示されることを確認
- [x] `vp test` がすべて通ること（既存の失敗3件を除く）

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)