### PR TITLE
fix: .envでClaudeモデルを切り替えられるよう設定を整備する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,11 @@ VITE_LLM_PROVIDER=local
 
 # === Claude API settings (when VITE_LLM_PROVIDER=claude) ===
 VITE_ANTHROPIC_API_KEY=your-api-key-here
-VITE_CLAUDE_MODEL=claude-opus-4-6
+# Claude model to use (claude provider only)
+# Options:
+#   claude-sonnet-4-6          (高品質・デフォルト)
+#   claude-haiku-4-5-20251001  (高速・低コスト)
+VITE_CLAUDE_MODEL=claude-sonnet-4-6
 
 # === Local LLM settings (when VITE_LLM_PROVIDER=local) ===
 VITE_LLM_BASE_URL=http://localhost:1234

--- a/src/api/llm.ts
+++ b/src/api/llm.ts
@@ -38,7 +38,7 @@ async function streamClaude(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
-      model: import.meta.env["VITE_CLAUDE_MODEL"] || "claude-opus-4-6",
+      model: import.meta.env["VITE_CLAUDE_MODEL"] || "claude-sonnet-4-6",
       max_tokens: 500,
       stream: true,
       system: systemPrompt,


### PR DESCRIPTION
## Summary
- `src/api/llm.ts` のデフォルトモデルを `claude-opus-4-6` → `claude-sonnet-4-6` に変更
- `.env.example` に利用可能なモデルID（Sonnet・Haiku）をコメントで列挙

## Test plan
- [ ] `.env` に `VITE_CLAUDE_MODEL=claude-haiku-4-5-20251001` を設定してモデルが切り替わることを確認
- [ ] `.env` に `VITE_CLAUDE_MODEL` を設定しない場合、`claude-sonnet-4-6` がデフォルトで使われることを確認

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)